### PR TITLE
Updated Core Module Formatting Configuration

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -58,3 +58,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 healthos = "linuxforhealth.healthos.core.cli:main"
+
+[tool.isort]
+profile = "black"

--- a/core/src/linuxforhealth/healthos/core/app/__init__.py
+++ b/core/src/linuxforhealth/healthos/core/app/__init__.py
@@ -12,6 +12,7 @@ from typing import Dict, List
 
 import uvicorn
 import yaml
+from aiokafka import ConsumerStoppedError
 from fastapi import FastAPI
 from pydantic import ValidationError
 
@@ -30,7 +31,6 @@ from ..connector import (
     get_kafka_consumer_connectors,
 )
 from .admin import router as admin_router
-from aiokafka import ConsumerStoppedError
 
 logger = logging.getLogger(__name__)
 

--- a/core/src/linuxforhealth/healthos/core/connector/__init__.py
+++ b/core/src/linuxforhealth/healthos/core/connector/__init__.py
@@ -9,8 +9,8 @@ from .nats import (
     create_inbound_jetstream_clients,
     create_jetstream_core_client,
     get_jetstream_clients,
-    get_jetstream_core_client,
     get_jetstream_connections,
+    get_jetstream_core_client,
 )
 from .processor import PublishDataModel
 from .rest import create_inbound_connector_route


### PR DESCRIPTION
Added a config to the core module's pyproject.toml to integrate the black and isort formatting tools so that the tools use the same formatting rules and don't work "against" each other.

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>