### PR TITLE
Integrate NATS Into Package Installation

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,12 +1,12 @@
 # HealthOS Build Documentation
 
-The current HealthOS target platform is Ubuntu 22.02, aka the "Jammy" release. HealthOS components are delivered as
+The current HealthOS target platform is the Ubuntu 22.02 "Jammy" release. HealthOS components are delivered as
 a tarball and installed using a shell script. 
 
 The HealthOS is deployed to the following file structure. 
 
 ```shell
-user@MBP /opt % tree /opt/healthos
+user@workstation /opt % tree /opt/healthos
 /opt/healthos
 ├── core
 │   ├── healthos-core-config.yml
@@ -18,28 +18,53 @@ user@MBP /opt % tree /opt/healthos
 In the example above, `/opt/healthos` is the base installation directory. HealthOS modules, such as the `core` module
 listed above are installed as subdirectories. 
 
-HealthOS modules utilize the same configuration footprint. Files within HealthOS modules include:
+HealthOS modules utilize the same configuration footprint. Common files within each HealthOS module includes:
 
 - healthos-<module name>-config.yml: Configuration settings for the HealthOS module.
 - linuxforhealth_healthos_<module name><version>.whl: The distribution file for the HealthOS module.
 - requirements.txt: The HealthOS module 3rd party dependencies.
 
+## Install HealthOS on Target Server
 
-## Create Installation Package (Tarball)
-
-The following command creates a new "package" in `install/lfh-healthos.tar.gz`
+First, create a HealthOS package (tarball) using the default `make` target. 
 
 ```shell
-user HealthOS % make
+user@workstation HealthOS % make
 ```
 
-## Install HealthOS Components
+The target creates a file in `install/lfh-healthos.tar.gz`
 
-First, upload lfh-healthos.tar.gz to the target server's /opt directory.
+Next, upload the tarball to the server.
 
-Next, extract the tarball and run the installation script.
+Once the tarball has been uploaded, extract the contents to the `/opt` directory and run the installation script.
 ```shell
 cd /opt
 tar -xvzf lfh-healthos.tar.gz
 ./healthos/install.sh
+```
+
+## Test HealthOS Installation With Docker
+
+First, create the HealthOS package.
+
+```shell
+user@workstation HealthOS % make
+```
+
+Next, launch an ephemeral docker container and open a shell.
+```shell
+user HealthOS % docker run -it --rm --name jammy ubuntu:jammy bash
+```
+
+In a second terminal session, copy the installation package into the container.
+```shell
+docker cp install/lfh-healthos*tar.gz jammy:/opt
+```
+
+Return to the first terminal session, which is running the container shell, and extract the installation package.
+```shell
+cd /opt
+tar -xvzf lfh-healthos*tar.gz
+cd /healthos
+./install.sh
 ```

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -65,6 +65,6 @@ Return to the first terminal session, which is running the container shell, and 
 ```shell
 cd /opt
 tar -xvzf lfh-healthos*tar.gz
-cd /healthos
+cd healthos
 ./install.sh
 ```


### PR DESCRIPTION
This PR integrates NATS into the install.sh script as an internal component. Primary changes include:

- updated build documentation including a testing section with docker
- refactored install.sh to use `getopt` rather than positional arguments
- integrated NATS into install.sh setup