### PR TITLE
Publish Errors to NATS

### DIFF
--- a/core/resources/service-config/demo-config.yml
+++ b/core/resources/service-config/demo-config.yml
@@ -30,7 +30,5 @@ app:
   debug: False
   messaging:
     url: "nats://localhost:4222"
-    stream_name: healthos
-    inbound_subject: ingress
 
 logging_config: logging.yaml

--- a/core/resources/service-config/healthos-core-config.yml
+++ b/core/resources/service-config/healthos-core-config.yml
@@ -12,7 +12,5 @@ app:
   debug: False
   messaging:
     url: "nats://localhost:4222"
-    stream_name: healthos
-    inbound_subject: ingress
 
 logging_config: /opt/lfh/healthos/logging.yml

--- a/core/resources/service-config/quickstart-config.yml
+++ b/core/resources/service-config/quickstart-config.yml
@@ -12,7 +12,5 @@ app:
   debug: False
   messaging:
     url: "nats://localhost:4222"
-    stream_name: healthos
-    inbound_subject: ingress
 
 logging_config: logging.yaml

--- a/core/src/linuxforhealth/healthos/core/app/__init__.py
+++ b/core/src/linuxforhealth/healthos/core/app/__init__.py
@@ -85,6 +85,7 @@ def core_startup(args):
         startup_internal_nats = partial(
             create_jetstream_core_client,
             core_config.app.messaging.url,
+            core_config.app.messaging.stream_name,
             [
                 core_config.app.messaging.ingress_subject,
                 core_config.app.messaging.error_subject,

--- a/core/src/linuxforhealth/healthos/core/app/__init__.py
+++ b/core/src/linuxforhealth/healthos/core/app/__init__.py
@@ -85,8 +85,8 @@ def core_startup(args):
         startup_internal_nats = partial(
             create_jetstream_core_client,
             core_config.app.messaging.url,
-            core_config.app.messaging.stream_name,
-            core_config.app.messaging.inbound_subject,
+            [core_config.app.messaging.ingress_subject,
+             core_config.app.messaging.error_subject],
         )
         core_service_app.add_event_handler("startup", startup_internal_nats)
 

--- a/core/src/linuxforhealth/healthos/core/app/__init__.py
+++ b/core/src/linuxforhealth/healthos/core/app/__init__.py
@@ -85,8 +85,10 @@ def core_startup(args):
         startup_internal_nats = partial(
             create_jetstream_core_client,
             core_config.app.messaging.url,
-            [core_config.app.messaging.ingress_subject,
-             core_config.app.messaging.error_subject],
+            [
+                core_config.app.messaging.ingress_subject,
+                core_config.app.messaging.error_subject,
+            ],
         )
         core_service_app.add_event_handler("startup", startup_internal_nats)
 

--- a/core/src/linuxforhealth/healthos/core/config/app.py
+++ b/core/src/linuxforhealth/healthos/core/config/app.py
@@ -5,7 +5,7 @@ Defines the data model used to support the Core service's "app" configuration.
 The Core service app provides the event loop used for core service components such as connectors, as
 well as Admin API interfaces.
 """
-from typing import Optional, Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 

--- a/core/src/linuxforhealth/healthos/core/config/app.py
+++ b/core/src/linuxforhealth/healthos/core/config/app.py
@@ -5,7 +5,7 @@ Defines the data model used to support the Core service's "app" configuration.
 The Core service app provides the event loop used for core service components such as connectors, as
 well as Admin API interfaces.
 """
-from typing import Optional
+from typing import Optional, Literal
 
 from pydantic import BaseModel, Field
 
@@ -19,14 +19,9 @@ class CoreAppMessaging(BaseModel):
         description="The URL for the core application messaging service (NATS Jetstream).",
         default="nats://localhost:4222",
     )
-    stream_name: str = Field(
-        description="The messaging stream name. Defaults to healthos.",
-        default="healthos",
-    )
-    inbound_subject: str = Field(
-        description="The messaging subject used to receive all inbound/ingress messages",
-        default="ingress",
-    )
+    stream_name: Literal["healthos"] = "healthos"
+    ingress_subject: Literal["core.ingress"] = "core.ingress"
+    error_subject: Literal["core.error"] = "core.error"
 
     class Config:
         extra = "forbid"

--- a/core/src/linuxforhealth/healthos/core/connector/nats.py
+++ b/core/src/linuxforhealth/healthos/core/connector/nats.py
@@ -28,16 +28,16 @@ jetstream_clients: List[JetStreamContext] | None = None
 jetstream_connections: List[nats.NATS] | None = None
 
 
-async def create_jetstream_core_client(url: str, stream_name: str, subject: str):
+async def create_jetstream_core_client(url: str, stream_name: str, subjects: str):
     """
     Creates a NATS client for the Core service.
     Additional operations include:
-    - creating the target stream and subject if they do not exist
+    - creating the target stream and subjects if they do not exist
     - associating the target subject with the NATS client instance
 
     :param url: The NATS server url, including protocol, host, and port.
     :param stream_name: The NATS server stream name
-    :param subject: The NATS server subject which is published to
+    :param subjects: The NATS server subjects used by the core module
     :return:
     """
     nats_connection: nats.NATS
@@ -58,7 +58,7 @@ async def create_jetstream_core_client(url: str, stream_name: str, subject: str)
     except NotFoundError:
         logger.info("HealthOS Stream Not Found Within NATS Jetstream Server")
         logger.info("Creating HealthOS Stream")
-        await jetstream_mgr.add_stream(name=stream_name, subjects=[subject])
+        await jetstream_mgr.add_stream(name=stream_name, subjects=subjects)
 
     global jetstream_core_client
     jetstream_core_client = nats_connection.jetstream()
@@ -138,5 +138,5 @@ async def inbound_connector_callback(msg):
     msg_str = msg.data.decode("utf-8")
     publish_model: PublishDataModel = await process_data(msg_str)
 
-    logger.debug(f"published message to {messaging_config.inbound_subject}")
+    logger.debug(f"published message to {messaging_config.ingress_subject}")
     logger.debug(f"message metadata {publish_model.dict()}")

--- a/core/src/linuxforhealth/healthos/core/connector/processor.py
+++ b/core/src/linuxforhealth/healthos/core/connector/processor.py
@@ -50,7 +50,7 @@ async def process_data(msg: str) -> PublishDataModel:
         content_type = detect_content_type(msg)
         publish_data["content_type"] = content_type
         validate_message(msg)
-    except (ContentTypeError, DataValidationError, KeyError, AttributeError) as ex:
+    except (ContentTypeError, DataValidationError) as ex:
         msg = f"Exception occurred processing data {ex}"
         logger.error(msg)
         publish_data["error"] = str(ex)

--- a/core/src/linuxforhealth/healthos/core/connector/processor.py
+++ b/core/src/linuxforhealth/healthos/core/connector/processor.py
@@ -55,18 +55,18 @@ async def process_data(msg: str) -> PublishDataModel:
 
     try:
         publish_ack = await core_client.publish(
-            subject=messaging_config.inbound_subject,
+            subject=messaging_config.ingress_subject,
             stream=messaging_config.stream_name,
             payload=message_payload,
         )
     except NoStreamResponseError as nsre:
-        msg = f"Unable to publish message to {messaging_config.stream_name}:{messaging_config.inbound_subject}"
+        msg = f"Unable to publish message to {messaging_config.stream_name}:{messaging_config.ingress_subject}"
         logger.error(msg)
         logger.error(f"NATS NoStreamResponseError {nsre}")
         raise
     else:
         logger.debug(
-            f"publishing to NATS {messaging_config.stream_name}:{messaging_config.inbound_subject}"
+            f"publishing to NATS {messaging_config.stream_name}:{messaging_config.ingress_subject}"
         )
         logger.debug(f"received NATS Ack {publish_ack}")
         logger.debug(f"returning status = received, id = {publish_model.data_id}")

--- a/core/src/linuxforhealth/healthos/core/connector/processor.py
+++ b/core/src/linuxforhealth/healthos/core/connector/processor.py
@@ -6,13 +6,20 @@ Common data processing implementations for HealthOS connectors.
 import json
 import logging
 import uuid
+from typing import Optional
 
 from nats.js import JetStreamContext
 from nats.js.errors import NoStreamResponseError
 from pydantic import BaseModel, Field
-from typing import Optional
+
 from ..config import get_core_configuration
-from ..detect import ContentType, validate_message, detect_content_type, ContentTypeError, DataValidationError
+from ..detect import (
+    ContentType,
+    ContentTypeError,
+    DataValidationError,
+    detect_content_type,
+    validate_message,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/core/src/linuxforhealth/healthos/core/detect.py
+++ b/core/src/linuxforhealth/healthos/core/detect.py
@@ -5,13 +5,29 @@ Provides functions pertaining to message format detection and validation.
 import json
 import logging
 from enum import Enum
-from typing import Dict
+from typing import Dict, Optional
 
 import hl7
+from hl7 import ParseException
 from fhir.resources import construct_fhir_element
 from linuxforhealth.x12.io import X12ModelReader
+from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
+
+
+class ContentTypeError(Exception):
+    """
+    Raised when a message has an invalid or unsupported content type.
+    """
+    pass
+
+
+class DataValidationError(Exception):
+    """
+    Raised when a data message contains validation errors.
+    """
+    pass
 
 
 class ContentType(str, Enum):
@@ -37,12 +53,12 @@ def detect_content_type(input_message: str) -> ContentType:
     If the content type cannot be determined, a ValueError is raised.
     :param input_message: The message to analyze
     :return: ContentType
-    :raises: ValueError if the content type cannot be determined
+    :raises: ContentTypeError if the content type cannot be determined
     """
     if input_message is None or len(input_message) < 3:
         msg = "input message is less than three characters"
         logger.error(msg)
-        raise ValueError(msg)
+        raise ContentTypeError(msg)
 
     first_chars = input_message.lstrip()[0:3].lower()
     content_type: ContentType | None = None
@@ -59,19 +75,21 @@ def detect_content_type(input_message: str) -> ContentType:
     if content_type is None:
         msg = "unable to determine content type"
         logger.error(msg)
-        raise ValueError(msg)
+        raise ContentTypeError(msg)
 
     return content_type
 
 
-def validate_message(input_message) -> ContentType:
+def validate_message(input_message: str, content_type: Optional[ContentType] = None):
     """
     Validates an input message based on it's detected content type.
     :param input_message: The input message to validate
-    :returns: The content type of the validated message
-    :raises: ValueError if the content type cannot be detected, or if the message is invalid.
+    :param content_type: The content type of the message. If not provided, the content type will be detected.
+    :raises: ContentTypeError if the content type is unsupported or invalid.
+    :raises: DataValidationError if the content type cannot be detected, or if the message is invalid.
     """
-    content_type: ContentType = detect_content_type(input_message)
+    if content_type is None:
+        content_type: ContentType = detect_content_type(input_message)
 
     try:
         match content_type:
@@ -87,8 +105,12 @@ def validate_message(input_message) -> ContentType:
 
             case ContentType.HL7_TEXT:
                 hl7.parse(input_message)
-    except Exception as ex:
+    # aggregate exception handling for the 3rd party model libraries
+    # ValidationError is a catch-all for Pydantic based models (fhir, x12)
+    # ParseException is raised by the hl7 library
+    # KeyError and AttributeError are additional exceptions which may be raised by x12
+    except (ValidationError, ParseException, KeyError, AttributeError) as ex:
         logger.error(f"Unable to load {content_type} due to {ex}")
-        raise ValueError(f"Unable to load {content_type}")
+        raise DataValidationError(str(ex))
 
     return content_type

--- a/core/src/linuxforhealth/healthos/core/detect.py
+++ b/core/src/linuxforhealth/healthos/core/detect.py
@@ -8,8 +8,8 @@ from enum import Enum
 from typing import Dict, Optional
 
 import hl7
-from hl7 import ParseException
 from fhir.resources import construct_fhir_element
+from hl7 import ParseException
 from linuxforhealth.x12.io import X12ModelReader
 from pydantic import ValidationError
 
@@ -20,6 +20,7 @@ class ContentTypeError(Exception):
     """
     Raised when a message has an invalid or unsupported content type.
     """
+
     pass
 
 
@@ -27,6 +28,7 @@ class DataValidationError(Exception):
     """
     Raised when a data message contains validation errors.
     """
+
     pass
 
 

--- a/core/tests/config/test_core_app_config.py
+++ b/core/tests/config/test_core_app_config.py
@@ -18,8 +18,6 @@ def config_data() -> Dict:
         "debug": True,
         "messaging": {
             "url": "nats://0.0.0.0:4223",
-            "stream_name": "core",
-            "inbound_subject": "landing_zone",
         },
     }
 
@@ -31,8 +29,9 @@ def test_validate_minimum_input(config_data: Dict):
     assert config.host == "0.0.0.0"
     assert config.debug is True
     assert config.messaging.url == "nats://0.0.0.0:4223"
-    assert config.messaging.stream_name == "core"
-    assert config.messaging.inbound_subject == "landing_zone"
+    assert config.messaging.stream_name == "healthos"
+    assert config.messaging.ingress_subject == "core.ingress"
+    assert config.messaging.error_subject == "core.error"
 
 
 def test_defaults(config_data: Dict):
@@ -43,4 +42,5 @@ def test_defaults(config_data: Dict):
     assert config.debug is False
     assert config.messaging.url == "nats://localhost:4222"
     assert config.messaging.stream_name == "healthos"
-    assert config.messaging.inbound_subject == "ingress"
+    assert config.messaging.ingress_subject == "core.ingress"
+    assert config.messaging.error_subject == "core.error"

--- a/core/tests/config/test_core_app_messaging.py
+++ b/core/tests/config/test_core_app_messaging.py
@@ -14,8 +14,6 @@ from linuxforhealth.healthos.core.config.app import CoreAppMessaging
 def config_data() -> Dict:
     return {
         "url": "nats://0.0.0.0:4223",
-        "stream_name": "core",
-        "inbound_subject": "landing_zone",
     }
 
 
@@ -23,8 +21,9 @@ def test_validate_minimum_input(config_data: Dict):
     """Validates the minimum input config for a CoreApp"""
     config = CoreAppMessaging(**config_data)
     assert config.url == "nats://0.0.0.0:4223"
-    assert config.stream_name == "core"
-    assert config.inbound_subject == "landing_zone"
+    assert config.stream_name == "healthos"
+    assert config.ingress_subject == "core.ingress"
+    assert config.error_subject == "core.error"
 
 
 def test_defaults(config_data: Dict):
@@ -32,4 +31,5 @@ def test_defaults(config_data: Dict):
     config = CoreAppMessaging()
     assert config.url == "nats://localhost:4222"
     assert config.stream_name == "healthos"
-    assert config.inbound_subject == "ingress"
+    assert config.ingress_subject == "core.ingress"
+    assert config.error_subject == "core.error"

--- a/core/tests/connector/test_processor.py
+++ b/core/tests/connector/test_processor.py
@@ -15,6 +15,7 @@ from linuxforhealth.healthos.core.connector.processor import (
     PublishDataModel,
     get_core_configuration,
     process_data,
+    ContentTypeError
 )
 
 
@@ -55,10 +56,9 @@ async def test_process_data(
     :param file_name: The file name containing the test message
     :param content_type: The message's expected content type
     """
-    config = core_configuration("core-service.yml")
     monkeypatch.setattr(
         "linuxforhealth.healthos.core.connector.processor.get_core_configuration",
-        lambda: config,
+        lambda:  core_configuration("core-service.yml"),
     )
 
     mock_js_client = AsyncMock(spec=JetStreamContext)
@@ -82,20 +82,34 @@ async def test_process_data(
 @pytest.mark.parametrize("invalid_file_name", ["demographics.csv", "invalid-270.x12"])
 @pytest.mark.asyncio
 async def test_process_data_invalid_content_type(
-    sample_data_path: str, invalid_file_name: str
+    monkeypatch, core_configuration, sample_data_path: str, invalid_file_name: str
 ):
     """
     Validates process_data when the message content type is invalid
 
+    :param monkeypatch: The pytest monkeypatch fixture
+    :param core_configuration: Fixture used to load a HealthOS Core Configuration Model
     :param sample_data_path: The path to the sample-data directory
     :param invalid_file_name: The file name containing the test message
     """
-    with pytest.raises(ValueError):
-        invalid_path = os.path.join(sample_data_path, invalid_file_name)
-        with open(invalid_path, "r") as f:
-            invalid_message = "".join(f.readlines())
+    monkeypatch.setattr(
+        "linuxforhealth.healthos.core.connector.processor.get_core_configuration",
+        lambda: core_configuration("core-service.yml"),
+    )
 
-        await process_data(invalid_message)
+    mock_js_client = AsyncMock(spec=JetStreamContext)
+    monkeypatch.setattr(
+        "linuxforhealth.healthos.core.connector.nats.get_jetstream_core_client",
+        lambda: mock_js_client,
+    )
+
+    invalid_path = os.path.join(sample_data_path, invalid_file_name)
+    with open(invalid_path, "r") as f:
+        invalid_message = "".join(f.readlines())
+
+    publish_model: PublishDataModel = await process_data(invalid_message)
+    assert publish_model.error is not None
+    assert mock_js_client.publish.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/core/tests/connector/test_processor.py
+++ b/core/tests/connector/test_processor.py
@@ -12,10 +12,10 @@ from nats.js import JetStreamContext
 from nats.js.errors import NoStreamResponseError
 
 from linuxforhealth.healthos.core.connector.processor import (
+    ContentTypeError,
     PublishDataModel,
     get_core_configuration,
     process_data,
-    ContentTypeError
 )
 
 
@@ -58,7 +58,7 @@ async def test_process_data(
     """
     monkeypatch.setattr(
         "linuxforhealth.healthos.core.connector.processor.get_core_configuration",
-        lambda:  core_configuration("core-service.yml"),
+        lambda: core_configuration("core-service.yml"),
     )
 
     mock_js_client = AsyncMock(spec=JetStreamContext)

--- a/core/tests/resources/service-config/core-service-invalid-logging.yml
+++ b/core/tests/resources/service-config/core-service-invalid-logging.yml
@@ -20,7 +20,5 @@ app:
   debug: False
   messaging:
     url: "nats://localhost:4222"
-    stream_name: healthos
-    inbound_subject: ingress
 
 logging_config: not-a-valid-logging.yaml

--- a/core/tests/resources/service-config/core-service.yml
+++ b/core/tests/resources/service-config/core-service.yml
@@ -28,7 +28,5 @@ app:
   debug: False
   messaging:
     url: "nats://localhost:4222"
-    stream_name: healthos
-    inbound_subject: ingress
 
 logging_config: logging.yaml

--- a/core/tests/resources/service-config/invalid-core-service.yml
+++ b/core/tests/resources/service-config/invalid-core-service.yml
@@ -20,7 +20,5 @@ app:
   debug: False
   messaging:
     url: "nats://localhost:4222"
-    stream_name: healthos
-    inbound_subject: ingress
 
 logging_config: logging.yaml

--- a/core/tests/test_detect.py
+++ b/core/tests/test_detect.py
@@ -7,6 +7,8 @@ import pytest
 
 from linuxforhealth.healthos.core.detect import (
     ContentType,
+    ContentTypeError,
+    DataValidationError,
     detect_content_type,
     validate_message,
 )
@@ -52,7 +54,7 @@ def test_detect_content_type_exception(sample_data_path: str):
     with open(file_path) as f:
         input_message = "".join(f.readlines())
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ContentTypeError):
         detect_content_type(input_message)
 
 
@@ -91,5 +93,5 @@ def test_validate_message_exception(sample_data_path: str):
     with open(file_path) as f:
         input_message = "".join(f.readlines())
 
-    with pytest.raises(ValueError):
+    with pytest.raises(DataValidationError):
         validate_message(input_message)

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -42,33 +42,3 @@ cd /opt
 tar -xvzf lfh-healthos.tar.gz
 ./healthos/install.sh
 ```
-
-## Test HealthOS Installation With Docker
-
-Note: Docker is a useful tool for validating that the installation process completes successfully and files are placed
-in the correct locations. The docker container may not be used to start HealthOS services since the HealthOS utilizes
-systemd for process management.
-
-First, create the HealthOS package.
-
-```shell
-user@workstation HealthOS % make
-```
-
-Next, launch an ephemeral docker container and open a shell.
-```shell
-user HealthOS % docker run -it --rm --name jammy ubuntu:jammy bash
-```
-
-In a second terminal session, copy the installation package into the container.
-```shell
-docker cp install/lfh-healthos*tar.gz jammy:/opt
-```
-
-Return to the first terminal session, which is running the container shell, and extract the installation package.
-```shell
-cd /opt
-tar -xvzf lfh-healthos*tar.gz
-cd healthos
-./install.sh
-```


### PR DESCRIPTION
This PR updates the HealthOS core module to publish ingress related errors to a specific nats subject, "core.errors".

Changes include:

- refactored app messaging model to use literal/constant values for the nats stream and subjects. moving forward these will be well known settings that are not configurable.
- updated the functions in the detect module to raise specific exceptions when an error occurs detecting a content type or validating a message.
- updated process_data to utilize the new specific exceptions from the detect module and publish errors to the nats error subject.

I have verified that unit tests are passing and that the demo readme transactions run without error.